### PR TITLE
raise direction output while transmitting

### DIFF
--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -177,10 +177,10 @@ uint32_t tim_table[][6] = {
 
 /* Time to delay TX empty notification, rounded up to nearest millisecond */
 int tx_empty_delay[] = {
-	32, //    300
-	8, //   1200
-	4, //   2400
-	2, //   4800
+	64, //    300
+	16, //   1200
+	8, //   2400
+	4, //   4800
 	1, //   9600
 	1, //  14400
 	1, //  19200


### PR DESCRIPTION
Raise the direction output associated with each port when that port is
transmitting rather than raising it when RTS is set and lowering it when
RTS is cleared. This results in RS485 transmitter being turned on for
less time than if it's controlled with RTS which make it possible to
communicate with devices which reply in under 3ms.

Mantis ID: 5839

Signed-off-by: George McCollister <george.mccollister@gmail.com>